### PR TITLE
add batch request support

### DIFF
--- a/addons/no-obs-ws/NoOBSWS.gd
+++ b/addons/no-obs-ws/NoOBSWS.gd
@@ -7,6 +7,7 @@ const Enums := preload("res://addons/no-obs-ws/Utility/Enums.gd")
 var _ws: WebSocketPeer
 # {request_id: RequestResponse}
 var _requests: Dictionary = {}
+var _batch_requests: Dictionary = {}
 
 const WS_URL := "127.0.0.1:%s"
 
@@ -51,6 +52,23 @@ func make_generic_request(request_type: String, request_data: Dictionary = {}) -
 	_send_message(message)
 
 	return response
+
+
+func make_batch_request(halt_on_failure: bool = false, execution_type: Enums.RequestBatchExecutionType = Enums.RequestBatchExecutionType.SERIAL_REALTIME) -> BatchRequest:
+	var batch_request := BatchRequest.new()
+
+	var crypto := Crypto.new()
+	var request_id := crypto.generate_random_bytes(16).hex_encode()
+
+	batch_request._id = request_id
+	batch_request._send_callback = _send_message
+
+	batch_request.halt_on_failure = halt_on_failure
+	batch_request.execution_type = execution_type
+
+	_batch_requests[request_id] = batch_request
+
+	return batch_request
 
 
 func _process(_delta: float) -> void:
@@ -115,6 +133,22 @@ func _handle_message(message: Message) -> void:
 
 			response.response_received.emit()
 			_requests.erase(id)
+
+		Enums.WebSocketOpCode.REQUEST_BATCH_RESPONSE:
+			var id = message.get_data().get("request_id")
+			if id == null:
+				error.emit("Received batch request response, but there was no request id field.")
+				return
+
+			var response = _batch_requests.get(id) as BatchRequest
+			if response == null:
+				error.emit("Received batch request response, but there was no request made with that id.")
+				return
+
+			response.response = message
+
+			response.response_received.emit()
+			_batch_requests.erase(id)
 
 
 func _send_message(message: Message) -> void:
@@ -226,3 +260,53 @@ class RequestResponse:
 	var id: String
 	var type: String
 	var message: Message
+
+
+class BatchRequest:
+	signal response_received()
+
+	var _id: String
+	var _send_callback: Callable
+
+	var halt_on_failure: bool = false
+	var execution_type: Enums.RequestBatchExecutionType = Enums.RequestBatchExecutionType.SERIAL_REALTIME
+
+	var requests: Array[Message]
+	# {String: int}
+	var request_ids: Dictionary
+
+	var response: Message = null
+
+	func send() -> void:
+		var message = Message.new()
+		message.op_code = Enums.WebSocketOpCode.REQUEST_BATCH
+		message._d["halt_on_failure"] = halt_on_failure
+		message._d["execution_type"] = execution_type
+		message._d["request_id"] = _id
+		message._d["requests"] = []
+		for r in requests:
+			message._d.requests.append(Message.snake_to_camel_recursive(r.get_data()))
+
+		_send_callback.call(message)
+
+
+	func add_request(request_type: String, request_id: String = "", request_data: Dictionary = {}) -> int:
+		var message = Message.new()
+
+		if request_id == "":
+			var crypto := Crypto.new()
+			request_id = crypto.generate_random_bytes(16).hex_encode()
+
+		var data := {
+			"request_type": request_type,
+			"request_id": request_id,
+			"request_data": request_data,
+		}
+
+		message._d.merge(data, true)
+		message.op_code = Enums.WebSocketOpCode.REQUEST
+
+		requests.append(message)
+		request_ids[request_id] = requests.size() - 1
+
+		return request_ids[request_id]


### PR DESCRIPTION
Allows making batch requests as specified in the [obs-websocket protocol](https://github.com/obsproject/obs-websocket/blob/master/docs/generated/protocol.md#requestbatch-opcode-8) through a special promise object, `BatchRequest`. To make such an object, the method `make_batch_request()` must be used:
```gdscript
var batch_request: NoOBSWS.BatchRequest = no_obsws.make_batch_request()
# Add requests to batch
batch_request.add_request("GetVersion", "id_for_getversion")
batch_request.add_request("GetStats", "id_for_getstats")
# Send the request
batch_request.send()

# Wait for the request response
await batch_request.response_received

# The response has been received and can be inspected
var batch_response = batch_request.response
```

The `make_batch_request()` method takes two optional arguments, `halt_on_failure: bool` and `execution_type: Enums.RequestBatchExecutionType`, with defaults the same as specified in the protocol.

At some point in the future, the API for `RequestResponse` will be changed, and the property `message` will be called `response` to match `BatchRequest`.