### PR TITLE
Patches incorrect casing in OBSws Fields.

### DIFF
--- a/addons/no-obs-ws/NoOBSWS.gd
+++ b/addons/no-obs-ws/NoOBSWS.gd
@@ -259,7 +259,7 @@ class Message:
 		var cameled = {}
 		for prop in d:
 			prop = prop as String
-			if d[prop] is Dictionary:
+			if d[prop] is Dictionary and not prop == "inputSettings":
 				cameled[prop.to_camel_case()] = snake_to_camel_recursive(d[prop])
 			else:
 				cameled[prop.to_camel_case()] = d[prop]

--- a/addons/no-obs-ws/NoOBSWS.gd
+++ b/addons/no-obs-ws/NoOBSWS.gd
@@ -259,7 +259,7 @@ class Message:
 		var cameled = {}
 		for prop in d:
 			prop = prop as String
-			if d[prop] is Dictionary and not prop == "inputSettings":
+			if d[prop] is Dictionary and prop != "inputSettings":
 				cameled[prop.to_camel_case()] = snake_to_camel_recursive(d[prop])
 			else:
 				cameled[prop.to_camel_case()] = d[prop]


### PR DESCRIPTION
Since OBSws is unfortunately painful it doesn't use consistent casing.  The arguments of the requests are in "camelCase" while, at least some arguments inside input_settings are *not*.  

So this patch ignores anything in inputSettings, and forces inputSettings to be supplied in camel case.  Allowing things like, say "local_file" for setting Media sources file path to work.